### PR TITLE
Add description column to profile

### DIFF
--- a/db/migrate/20230613113632_add_description_to_profiles.rb
+++ b/db/migrate/20230613113632_add_description_to_profiles.rb
@@ -1,4 +1,4 @@
-class AddDescriptionToProfile < ActiveRecord::Migration[6.0]
+class AddDescriptionToProfiles < ActiveRecord::Migration[6.0]
   def change
     add_column :profiles, :description, :text
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_06_05_160110) do
+ActiveRecord::Schema.define(version: 2023_06_13_113632) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -61,8 +61,8 @@ ActiveRecord::Schema.define(version: 2023_06_05_160110) do
     t.boolean "subscribed"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.text "description"
     t.string "division"
+    t.text "description"
     t.index ["user_id"], name: "index_profiles_on_user_id"
   end
 


### PR DESCRIPTION
以下のエラーが出たので、一度カラムを削除し、再度追加した。
PG::DuplicateColumn: ERROR:  column "description" of relation "profiles" already exists